### PR TITLE
Fix atom link

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -6,7 +6,7 @@
 		<meta charset="UTF-8" />
 		<meta name="author" content="Mike McQuaid" />
 		<meta name="viewport" content="width=device-width, height=device-height, user-scalable=no" />
-		<link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="http://{{ site.url }}/atom.xml" />
+		<link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ site.url }}/atom.xml" />
 		<link rel="openid2.provider" href="https://openid.stackexchange.com/openid/provider" />
 		<link rel="openid2.local_id" href="https://openid.stackexchange.com/user/1c09c8e2-a424-4648-81b5-283328dbdc71" />
 		<script type="text/javascript">


### PR DESCRIPTION
I noticed a double `http://` in the feed link when I tried to subscribe. Here's a quick fix.

&mdash; :penguin: